### PR TITLE
Spatial Voice Chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ type PlayerState = {
 
 #### Network Layer
 
-_Provides multiplayer out-of-the-box. Muse provides signalling servers for everyone, but not STUN/TURN servers, which [you need for best performance](https://www.twilio.com/docs/stun-turn/faq#faq-what-is-nat)._
+_Provides multiplayer out-of-the-box. Muse provides signalling servers and STUN/TURN for everyone :)._
 
 ```tsx
 type NetworkProps = {
@@ -200,6 +200,7 @@ type NetworkProps = {
   host?: string; // signalling host url, uses Muse's servers by default
   sessionId?: string; // if you know the session id you want to use, enter it here
   worldName?: string; // the worldname to hash your signal peers by, by default set to the path name
+  voice?: boolean; // whether to enable spatial voice chat, false by default
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ type PlayerState = {
 
 #### Network Layer
 
-_Provides multiplayer out-of-the-box. Muse provides signalling servers and STUN/TURN for everyone :)._
+_Provides multiplayer out-of-the-box. Muse provides signalling servers and [STUN/TURN](https://www.twilio.com/docs/stun-turn/faq#faq-what-is-nat) servers for everyone :)._
 
 ```tsx
 type NetworkProps = {

--- a/examples/worlds/Multiplayer/index.tsx
+++ b/examples/worlds/Multiplayer/index.tsx
@@ -5,7 +5,7 @@ export default function Multiplayer() {
   return (
     <StandardReality
       playerProps={{ pos: [5, 1, 0], rot: Math.PI }}
-      networkProps={{ autoconnect: true }}
+      networkProps={{ autoconnect: true, voice: true }}
     >
       <Background color={0xffffff} />
       <fog attach="fog" args={[0xffffff, 10, 90]} />

--- a/src/layers/Environment/logic/environment.ts
+++ b/src/layers/Environment/logic/environment.ts
@@ -7,6 +7,7 @@ import {
   useState,
 } from "react";
 import { Device, DeviceState, useDevice } from "./device";
+import { AudioContext } from "three";
 
 export type MenuItem = { text: string; action: () => void };
 
@@ -33,6 +34,12 @@ export const useEnvironmentState = (name: string): EnvironmentState => {
 
   const setPaused = (p: boolean) => {
     setPausedValue(p);
+
+    // hook into paused click event to make sure global context is running
+    // https://github.com/mrdoob/three.js/blob/342946c8392639028da439b6dc0597e58209c696/src/audio/AudioContext.js#L9
+    const context = AudioContext.getContext();
+    if (context.state !== "running") context.resume();
+
     // call all pause events
     events.map((ev: PauseEvent) => ev.apply(null, [p]));
   };

--- a/src/layers/Network/ideas/NetworkedEntities/index.tsx
+++ b/src/layers/Network/ideas/NetworkedEntities/index.tsx
@@ -3,7 +3,6 @@ import {
   CylinderBufferGeometry,
   InstancedMesh,
   MeshNormalMaterial,
-  PositionalAudio,
 } from "three";
 import { useNetwork } from "../../logic/network";
 import { useLimitedFrame } from "../../../../logic/limiter";
@@ -24,7 +23,6 @@ export default function NetworkedEntities() {
   const mat = useMemo(() => new MeshNormalMaterial(), []);
   const obj = useObj();
 
-  const posAudios = useMemo<PositionalAudio[]>(() => [], []);
   const entities = useEntities();
 
   // set up channel to send/receive data
@@ -91,7 +89,7 @@ export default function NetworkedEntities() {
       obj.updateMatrix();
       mesh.current.setMatrixAt(i, obj.matrix);
 
-      const audio = posAudios[i];
+      const audio = entities[i].posAudio;
       if (audio) {
         obj.matrix.decompose(audio.position, audio.quaternion, audio.scale);
       }

--- a/src/layers/Network/ideas/NetworkedEntities/index.tsx
+++ b/src/layers/Network/ideas/NetworkedEntities/index.tsx
@@ -89,10 +89,13 @@ export default function NetworkedEntities() {
       obj.updateMatrix();
       mesh.current.setMatrixAt(i, obj.matrix);
 
-      const audio = entities[i].posAudio;
+      const audio = entities[i]?.posAudio;
       if (audio) {
         obj.matrix.decompose(audio.position, audio.quaternion, audio.scale);
+        audio.updateMatrix();
+        audio.rotateY(Math.PI); // for some reason it's flipped
       }
+
       i++;
     }
 
@@ -108,10 +111,7 @@ export default function NetworkedEntities() {
       {entities.map(
         (entity) =>
           entity.posAudio && (
-            <primitive
-              key={entity.posAudio.userData.peerId}
-              object={entity.posAudio}
-            />
+            <primitive key={entity.posAudio.uuid} object={entity.posAudio} />
           )
       )}
       <instancedMesh

--- a/src/layers/Network/ideas/NetworkedEntities/logic/entity.ts
+++ b/src/layers/Network/ideas/NetworkedEntities/logic/entity.ts
@@ -1,8 +1,9 @@
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useLimitedFrame } from "../../../../../logic/limiter";
 import { useNetwork } from "../../../logic/network";
 import { PositionalAudio } from "three";
 import { useListener } from "./resources";
+import { PositionalAudioHelper } from "three/examples/jsm/helpers/PositionalAudioHelper";
 
 type Entity = {
   id: string;
@@ -22,25 +23,24 @@ export const useEntities = (): Entity[] => {
     ids1.sort().join(",") === ids2.sort().join(",");
 
   // check for a change in player list, re-render if there is a change
-  const [connectionIds, setConnectionIds] = useState<string[]>([]);
-  const [voiceIds, setVoiceIds] = useState<string[]>([]);
+  const connectionIds = useRef<string[]>([]);
+  const voiceIds = useRef<string[]>([]);
   useLimitedFrame(6, () => {
     if (!connected) return;
 
     // check for changes in connections
-    const locConnectionIds = Array.from(connections.keys());
-    if (!sameIds(connectionIds, locConnectionIds)) {
-      setConnectionIds(locConnectionIds);
+    if (!sameIds(connectionIds.current, Array.from(connections.keys()))) {
+      connectionIds.current = Array.from(connections.keys());
 
       // remove entities that are no longer connected
       entities.map((e) => {
-        if (!locConnectionIds.includes(e.id)) {
+        if (!connectionIds.current.includes(e.id)) {
           entities.splice(entities.indexOf(e), 1);
         }
       });
 
       // add in new entities
-      for (const id of locConnectionIds) {
+      for (const id of connectionIds.current) {
         if (!entities.some((e) => e.id === id)) {
           entities.push({ id, posAudio: undefined });
         }
@@ -49,37 +49,35 @@ export const useEntities = (): Entity[] => {
       rerender();
     }
 
-    const locVoiceIds = Array.from(voiceStreams.keys());
-    if (!sameIds(voiceIds, locVoiceIds)) {
-      setVoiceIds(locVoiceIds);
+    if (!sameIds(voiceIds.current, Array.from(voiceStreams.keys()))) {
+      voiceIds.current = Array.from(voiceStreams.keys());
 
       // remove voice streams that are no longer connected
       entities.map((e) => {
-        if (!locVoiceIds.includes(e.id)) {
+        if (!voiceIds.current.includes(e.id)) {
           e.posAudio?.remove();
           e.posAudio = undefined;
         }
       });
 
       // add in new voice streams
-      for (const id of locVoiceIds) {
-        if (!entities.some((e) => e.id === id)) {
-          entities.push({ id, posAudio: undefined });
-        }
-
-        const entity = entities.find((e) => e.id === id)!;
+      for (const id of voiceIds.current) {
+        const entity = entities.find((e) => e.id === id);
+        if (!entity) continue;
 
         const stream = voiceStreams.get(id)!;
+        if (!stream) continue;
 
         const audioElem = document.createElement("audio");
-        audioElem.autoplay = true;
         audioElem.srcObject = stream;
-        audioElem.muted = true;
+        audioElem.autoplay = true;
         const posAudio = new PositionalAudio(listener);
         posAudio.userData.peerId = id;
         posAudio.setMediaStreamSource(audioElem.srcObject);
-        posAudio.setRefDistance(2);
-        posAudio.setDirectionalCone(150, 230, 0.2);
+        posAudio.setRefDistance(3);
+        posAudio.setDirectionalCone(200, 290, 0.2);
+        audioElem.muted = true;
+        // posAudio.add(new PositionalAudioHelper(posAudio, 1));
         entity.posAudio = posAudio;
       }
 

--- a/src/layers/Network/ideas/NetworkedEntities/logic/entity.ts
+++ b/src/layers/Network/ideas/NetworkedEntities/logic/entity.ts
@@ -82,7 +82,7 @@ export const useEntities = (): Entity[] => {
         audioElem.autoplay = true;
         audioElem.loop = true;
         //@ts-ignore
-        audioElem.playsinline = true;
+        audioElem.playsInline = true;
 
         const posAudio = new PositionalAudio(listener);
         posAudio.userData.peerId = id;

--- a/src/layers/Network/ideas/NetworkedEntities/logic/entity.ts
+++ b/src/layers/Network/ideas/NetworkedEntities/logic/entity.ts
@@ -1,0 +1,91 @@
+import { useMemo, useState } from "react";
+import { useLimitedFrame } from "../../../../../logic/limiter";
+import { useNetwork } from "../../../logic/network";
+import { PositionalAudio } from "three";
+import { useListener } from "./resources";
+
+type Entity = {
+  id: string;
+  posAudio: PositionalAudio | undefined;
+};
+
+export const useEntities = (): Entity[] => {
+  const { connections, connected, voiceStreams } = useNetwork();
+
+  const listener = useListener();
+  const [ct, setCt] = useState(0);
+  const rerender = () => setCt(Math.random());
+
+  const entities = useMemo<Entity[]>(() => [], []);
+
+  const sameIds = (ids1: string[], ids2: string[]) =>
+    ids1.sort().join(",") === ids2.sort().join(",");
+
+  // check for a change in player list, re-render if there is a change
+  const [connectionIds, setConnectionIds] = useState<string[]>([]);
+  const [voiceIds, setVoiceIds] = useState<string[]>([]);
+  useLimitedFrame(6, () => {
+    if (!connected) return;
+
+    // check for changes in connections
+    const locConnectionIds = Array.from(connections.keys());
+    if (!sameIds(connectionIds, locConnectionIds)) {
+      setConnectionIds(locConnectionIds);
+
+      // remove entities that are no longer connected
+      entities.map((e) => {
+        if (!locConnectionIds.includes(e.id)) {
+          entities.splice(entities.indexOf(e), 1);
+        }
+      });
+
+      // add in new entities
+      for (const id of locConnectionIds) {
+        if (!entities.some((e) => e.id === id)) {
+          entities.push({ id, posAudio: undefined });
+        }
+      }
+
+      rerender();
+    }
+
+    const locVoiceIds = Array.from(voiceStreams.keys());
+    if (!sameIds(voiceIds, locVoiceIds)) {
+      setVoiceIds(locVoiceIds);
+
+      // remove voice streams that are no longer connected
+      entities.map((e) => {
+        if (!locVoiceIds.includes(e.id)) {
+          e.posAudio?.remove();
+          e.posAudio = undefined;
+        }
+      });
+
+      // add in new voice streams
+      for (const id of locVoiceIds) {
+        if (!entities.some((e) => e.id === id)) {
+          entities.push({ id, posAudio: undefined });
+        }
+
+        const entity = entities.find((e) => e.id === id)!;
+
+        const stream = voiceStreams.get(id)!;
+
+        const audioElem = document.createElement("audio");
+        audioElem.autoplay = true;
+        audioElem.srcObject = stream;
+        audioElem.muted = true;
+        const posAudio = new PositionalAudio(listener);
+        posAudio.userData.peerId = id;
+        posAudio.setMediaStreamSource(audioElem.srcObject);
+        posAudio.setRefDistance(2);
+        posAudio.setDirectionalCone(150, 230, 0.2);
+        entity.posAudio = posAudio;
+      }
+
+      rerender();
+    }
+  });
+
+  return entities;
+};

--- a/src/layers/Network/ideas/NetworkedEntities/logic/entity.ts
+++ b/src/layers/Network/ideas/NetworkedEntities/logic/entity.ts
@@ -66,18 +66,25 @@ export const useEntities = (): Entity[] => {
         if (!entity) continue;
 
         const stream = voiceStreams.get(id)!;
+        console.log(stream);
         if (!stream) continue;
 
         const audioElem = document.createElement("audio");
         audioElem.srcObject = stream;
+        // audioElem.muted = true;
         audioElem.autoplay = true;
+        audioElem.loop = true;
+        //@ts-ignore
+        audioElem.playsinline = true;
+
         const posAudio = new PositionalAudio(listener);
         posAudio.userData.peerId = id;
-        posAudio.setMediaStreamSource(audioElem.srcObject);
+        posAudio.setMediaStreamSource(stream);
         posAudio.setRefDistance(3);
         posAudio.setDirectionalCone(200, 290, 0.2);
-        audioElem.muted = true;
-        // posAudio.add(new PositionalAudioHelper(posAudio, 1));
+        posAudio.setVolume(0.75);
+
+        posAudio.add(new PositionalAudioHelper(posAudio, 1));
         entity.posAudio = posAudio;
       }
 

--- a/src/layers/Network/ideas/NetworkedEntities/logic/entity.ts
+++ b/src/layers/Network/ideas/NetworkedEntities/logic/entity.ts
@@ -74,7 +74,6 @@ export const useEntities = (): Entity[] => {
         if (!entity) continue;
 
         const stream = voiceStreams.get(id)!;
-        console.log(stream);
         if (!stream) continue;
 
         const audioElem = document.createElement("audio");

--- a/src/layers/Network/ideas/NetworkedEntities/logic/entity.ts
+++ b/src/layers/Network/ideas/NetworkedEntities/logic/entity.ts
@@ -71,7 +71,7 @@ export const useEntities = (): Entity[] => {
 
         const audioElem = document.createElement("audio");
         audioElem.srcObject = stream;
-        // audioElem.muted = true;
+        audioElem.muted = true;
         audioElem.autoplay = true;
         audioElem.loop = true;
         //@ts-ignore
@@ -80,11 +80,13 @@ export const useEntities = (): Entity[] => {
         const posAudio = new PositionalAudio(listener);
         posAudio.userData.peerId = id;
         posAudio.setMediaStreamSource(stream);
-        posAudio.setRefDistance(3);
+        posAudio.setRefDistance(2);
         posAudio.setDirectionalCone(200, 290, 0.2);
-        posAudio.setVolume(0.75);
+        posAudio.setVolume(0.6);
 
-        posAudio.add(new PositionalAudioHelper(posAudio, 1));
+        listener.context.resume();
+
+        // posAudio.add(new PositionalAudioHelper(posAudio, 1));
         entity.posAudio = posAudio;
       }
 

--- a/src/layers/Network/ideas/NetworkedEntities/logic/resources.ts
+++ b/src/layers/Network/ideas/NetworkedEntities/logic/resources.ts
@@ -1,0 +1,20 @@
+import { useThree } from "@react-three/fiber";
+import { useMemo } from "react";
+import { AudioListener, Object3D } from "three";
+
+export const useListener = (): AudioListener => {
+  const cam = useThree((st) => st.camera);
+  return useMemo(() => {
+    const listen = new AudioListener();
+    cam.add(listen);
+    return listen;
+  }, [cam]);
+};
+
+export const useObj = (): Object3D => {
+  return useMemo(() => {
+    const o = new Object3D();
+    o.matrixAutoUpdate = false;
+    return o;
+  }, []);
+};

--- a/src/layers/Network/ideas/NetworkedEntities/logic/resources.ts
+++ b/src/layers/Network/ideas/NetworkedEntities/logic/resources.ts
@@ -5,6 +5,7 @@ import { AudioListener, Object3D } from "three";
 export const useListener = (): AudioListener => {
   const cam = useThree((st) => st.camera);
   return useMemo(() => {
+    console.log("creating listener");
     const listen = new AudioListener();
     cam.add(listen);
     return listen;

--- a/src/layers/Network/ideas/NetworkedEntities/logic/resources.ts
+++ b/src/layers/Network/ideas/NetworkedEntities/logic/resources.ts
@@ -5,7 +5,6 @@ import { AudioListener, Object3D } from "three";
 export const useListener = (): AudioListener => {
   const cam = useThree((st) => st.camera);
   return useMemo(() => {
-    console.log("creating listener");
     const listen = new AudioListener();
     cam.add(listen);
     return listen;

--- a/src/layers/Network/logic/connection.ts
+++ b/src/layers/Network/logic/connection.ts
@@ -15,6 +15,7 @@ export type ConnectionState = {
   connections: Map<string, DataConnection>;
   voiceStreams: Map<string, MediaStream>;
   disconnect: () => void;
+  setVoice: (v: boolean) => void;
 } & Pick<Channels, "useChannel">;
 
 export type ConnectionConfig = {
@@ -120,7 +121,9 @@ export const useConnection = (
   };
 
   useWaving(1, signaller, disconnect);
-  const voiceStreams = useVoice(externalConfig.voice, peer, connections);
+
+  const [voice, setVoice] = useState(externalConfig.voice);
+  const voiceStreams = useVoice(voice, peer, connections);
 
   return {
     connected,
@@ -129,5 +132,6 @@ export const useConnection = (
     connections,
     voiceStreams,
     useChannel: channels.useChannel,
+    setVoice,
   };
 };

--- a/src/layers/Network/logic/connection.ts
+++ b/src/layers/Network/logic/connection.ts
@@ -6,6 +6,7 @@ import { MuseSignaller } from "./signallers/MuseSignaller";
 import { useWaving } from "./wave";
 import { Signaller, SignallerConfig } from "./signallers";
 import { Channels, useChannels } from "./channels";
+import { useVoice } from "../voice";
 
 export type ConnectionState = {
   connected: boolean;
@@ -16,6 +17,7 @@ export type ConnectionState = {
 
 export type ConnectionConfig = {
   iceServers?: RTCIceServer[];
+  voice?: boolean;
 } & SignallerConfig;
 
 export const useConnection = (
@@ -110,6 +112,7 @@ export const useConnection = (
   };
 
   useWaving(1, signaller, disconnect);
+  useVoice(externalConfig.voice, peer, connections);
 
   return {
     connected,

--- a/src/layers/Network/logic/connection.ts
+++ b/src/layers/Network/logic/connection.ts
@@ -7,6 +7,7 @@ import { useWaving } from "./wave";
 import { Signaller, SignallerConfig } from "./signallers";
 import { Channels, useChannels } from "./channels";
 import { useVoice } from "./voice";
+import { getMuseIceServers } from "./ice";
 
 export type ConnectionState = {
   connected: boolean;
@@ -59,8 +60,14 @@ export const useConnection = (
 
     const finalConfig = { ...externalConfig, ...config };
 
+    if (!finalConfig.iceServers) {
+      const servers = await getMuseIceServers(finalConfig.host);
+      if (servers) finalConfig.iceServers = servers;
+    }
+
     const peerConfig: any = {};
     if (finalConfig.iceServers) peerConfig.iceServers = finalConfig.iceServers;
+
     const p = new Peer({ config: peerConfig });
 
     p.on("connection", registerConnection); // incoming

--- a/src/layers/Network/logic/connection.ts
+++ b/src/layers/Network/logic/connection.ts
@@ -6,12 +6,13 @@ import { MuseSignaller } from "./signallers/MuseSignaller";
 import { useWaving } from "./wave";
 import { Signaller, SignallerConfig } from "./signallers";
 import { Channels, useChannels } from "./channels";
-import { useVoice } from "../voice";
+import { useVoice } from "./voice";
 
 export type ConnectionState = {
   connected: boolean;
   connect: (config?: ConnectionConfig) => Promise<void>;
   connections: Map<string, DataConnection>;
+  voiceStreams: Map<string, MediaStream>;
   disconnect: () => void;
 } & Pick<Channels, "useChannel">;
 
@@ -112,13 +113,14 @@ export const useConnection = (
   };
 
   useWaving(1, signaller, disconnect);
-  useVoice(externalConfig.voice, peer, connections);
+  const voiceStreams = useVoice(externalConfig.voice, peer, connections);
 
   return {
     connected,
     connect,
     disconnect,
     connections,
+    voiceStreams,
     useChannel: channels.useChannel,
   };
 };

--- a/src/layers/Network/logic/connection.ts
+++ b/src/layers/Network/logic/connection.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { DataConnection, Peer } from "peerjs";
 import { isLocalNetwork } from "./local";
 import { LocalSignaller } from "./signallers/LocalSignaller";
@@ -122,7 +122,8 @@ export const useConnection = (
 
   useWaving(1, signaller, disconnect);
 
-  const [voice, setVoice] = useState(externalConfig.voice);
+  const [voice, setVoice] = useState(!!externalConfig.voice);
+  useEffect(() => setVoice(!!externalConfig.voice), [externalConfig.voice]);
   const voiceStreams = useVoice(voice, peer, connections);
 
   return {

--- a/src/layers/Network/logic/ice.ts
+++ b/src/layers/Network/logic/ice.ts
@@ -1,0 +1,48 @@
+const KEY = "spacesvr-ice-servers";
+
+// 24 hours
+const EXPIRE_TIME = 24 * 60 * 60 * 1000;
+
+type IceStorage = {
+  iceServers: RTCIceServer[];
+  time: number;
+};
+
+const storeLocalIceServers = (servers: RTCIceServer[]) => {
+  const store: IceStorage = { iceServers: servers, time: new Date().getTime() };
+  localStorage.setItem(KEY, JSON.stringify(store));
+};
+
+const getLocalIceServers = (): RTCIceServer[] | undefined => {
+  const str = localStorage.getItem(KEY);
+  if (!str) return undefined;
+  try {
+    const res = JSON.parse(str) as IceStorage;
+    // clear if expired
+    if (new Date().getTime() - res.time > EXPIRE_TIME) {
+      localStorage.removeItem(KEY);
+      return undefined;
+    }
+    return res.iceServers;
+  } catch (err) {
+    return undefined;
+  }
+};
+
+export const getMuseIceServers = async (
+  host = "https://muse-web.onrender.com"
+): Promise<RTCIceServer[] | undefined> => {
+  const local = getLocalIceServers();
+  if (local) return local;
+
+  try {
+    const res = await fetch(`${host}/sessions/get_ice`);
+    const json = await res.json();
+    const servers = json.iceServers as RTCIceServer[];
+    storeLocalIceServers(servers);
+    return servers;
+  } catch (err) {
+    console.error("failed to fetch ice servers", err);
+    return undefined;
+  }
+};

--- a/src/layers/Network/logic/voice.ts
+++ b/src/layers/Network/logic/voice.ts
@@ -21,7 +21,6 @@ export const useVoice = (
     () => new Map<string, MediaStream>(),
     []
   );
-  const [ct, setCt] = useState(0);
 
   // attempt to request permission for microphone, only try once
   const [attempted, setAttempted] = useState(false);
@@ -67,13 +66,18 @@ export const useVoice = (
       });
 
       mediaConn.on("error", (err: any) => {
-        console.error(err);
+        console.error("error with voice stream with peer", mediaConn.peer, err);
+        voiceStreams.delete(mediaConn.peer);
       });
     };
 
     peer.on("call", handleMediaConn);
     peer.on("connection", (dataConn) => {
       handleMediaConn(peer.call(dataConn.peer, stream));
+      dataConn.on("close", () => {
+        console.log("closing voice stream with peer", dataConn.peer);
+        voiceStreams.delete(dataConn.peer);
+      });
     });
   }, [connections, peer, stream, voiceStreams]);
 

--- a/src/layers/Network/logic/voice.ts
+++ b/src/layers/Network/logic/voice.ts
@@ -56,8 +56,8 @@ export const useVoice = (
       console.log("media connection opened with peer", mediaConn.peer);
       mediaConn.answer(stream);
 
-      mediaConn.on("stream", (stream: MediaStream) => {
-        voiceStreams.set(mediaConn.peer, stream);
+      mediaConn.on("stream", (str: MediaStream) => {
+        voiceStreams.set(mediaConn.peer, str);
       });
 
       mediaConn.on("close", () => {

--- a/src/layers/Network/voice.ts
+++ b/src/layers/Network/voice.ts
@@ -1,0 +1,78 @@
+import { DataConnection, Peer, MediaConnection } from "peerjs";
+import { useEffect, useState } from "react";
+
+declare global {
+  interface Navigator {
+    getUserMedia(
+      options: { video?: boolean; audio?: boolean },
+      success: (stream: any) => void,
+      error?: (error: string) => void
+    ): void;
+  }
+}
+
+export const useVoice = (
+  enable: boolean | undefined,
+  peer: Peer | undefined,
+  connections: Map<string, DataConnection>
+): void => {
+  const [stream, setStream] = useState<MediaStream>();
+
+  // attempt to request permission for microphone, only try once
+  const [attempted, setAttempted] = useState(false);
+  useEffect(() => {
+    if (!enable || attempted) return;
+
+    navigator.getUserMedia =
+      navigator.getUserMedia ||
+      // @ts-ignore
+      navigator.webkitGetUserMedia ||
+      // @ts-ignore
+      navigator.mozGetUserMedia ||
+      // @ts-ignore
+      navigator.msGetUserMedia;
+
+    setAttempted(true);
+    navigator.getUserMedia(
+      { audio: true },
+      (stream: MediaStream) => {
+        setStream(stream);
+      },
+      (err) => {
+        console.error(err);
+        setStream(undefined);
+      }
+    );
+  }, [attempted, enable, peer]);
+
+  useEffect(() => {
+    if (!peer || !stream || !connections) return;
+
+    const handleMediaConn = (mediaConn: MediaConnection) => {
+      console.log("media connection opened with peer", mediaConn.peer);
+      mediaConn.answer(stream);
+
+      mediaConn.on("stream", (stream: MediaStream) => {
+        const audioElem = document.createElement("audio");
+        audioElem.id = mediaConn.peer;
+        audioElem.autoplay = true;
+        audioElem.srcObject = stream;
+        document.body.appendChild(audioElem);
+      });
+
+      mediaConn.on("close", () => {
+        const audioElem = document.getElementById(mediaConn.peer);
+        if (audioElem) audioElem.remove();
+      });
+
+      mediaConn.on("error", (err: any) => {
+        console.log(err);
+      });
+    };
+
+    peer.on("call", handleMediaConn);
+    peer.on("connection", (dataConn) => {
+      handleMediaConn(peer.call(dataConn.peer, stream));
+    });
+  }, [connections, peer, stream]);
+};


### PR DESCRIPTION
- adds new prop to `Network` layer: `voice`. when true, enables webrtc voice chat
- in the provided `NetworkedEntities`, voice streams are attached to positional audio elements and transformed in sync with visual entities
- by default use Muse STUN/TURN servers for all spacesvr projects, and cache those servers in local storage for 24 hours
- provide a `setVoice` function from the `Network` layer
- it's known to be a bit buggy on iphone/safari, will patch in a future update