### PR TITLE
v2.5.3

### DIFF
--- a/examples/worlds/Workshop.tsx
+++ b/examples/worlds/Workshop.tsx
@@ -78,25 +78,8 @@ export default function Workshop() {
         rotation={[0, Math.PI, 0]}
       />
       <Image
-        src="https://uploads.codesandbox.io/uploads/user/b3e56831-8b98-4fee-b941-0e27f39883ab/I9vI-RoNmD7W.png"
-        position={[-8, 2, 6.4]}
-        rotation={[0, Math.PI, 0]}
-        framed
-      />
-      <Image
-        src="https://uploads.codesandbox.io/uploads/user/b3e56831-8b98-4fee-b941-0e27f39883ab/I9vI-RoNmD7W.png"
-        position={[-11, 2, 6.4]}
-        rotation={[0, Math.PI, 0]}
-      />
-      <Image
         src="https://d1htv66kutdwsl.cloudfront.net/e7edec86-52b6-4734-9c43-ffd70bc5bef6/9d1e5c18-3fb5-4844-8b31-1a08b800976e.ktx2"
         position={[-12.5, 2, 6.4]}
-        rotation={[0, Math.PI, 0]}
-        framed
-      />
-      <Image
-        src="https://uploads.codesandbox.io/uploads/user/b3e56831-8b98-4fee-b941-0e27f39883ab/I9vI-RoNmD7W.png"
-        position={[-14, 2, 6.4]}
         rotation={[0, Math.PI, 0]}
         framed
       />

--- a/examples/worlds/Workshop.tsx
+++ b/examples/worlds/Workshop.tsx
@@ -41,6 +41,12 @@ export default function Workshop() {
 
   return (
     <StandardReality>
+      <Image
+        src="https://uploads.codesandbox.io/uploads/user/b3e56831-8b98s-4fee-b941-0e27f39883ab/I9vI-RoNmD7W.png"
+        position={[-8, 2, 6.4]}
+        rotation={[0, Math.PI, 0]}
+        framed
+      />
       <Analytics />
       <LostWorld />
       <group position-z={-2} position-x={-1}>
@@ -119,7 +125,7 @@ export default function Workshop() {
       </group>
       <Image
         name="outside-eddie"
-        src="https://d27rt3a60hh1lx.cloudfront.net/content/muse.place/jasonmatias/EddieWave.jpg"
+        src="https://d27rtd3a60hh1lx.cloudfront.net/content/muse.place/jasonmatias/EddieWave.jpg"
         framed
         frameWidth={0.75}
         size={12}

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@geckos.io/snapshot-interpolation": "^1.1.0",
     "@juggle/resize-observer": "^3.2.0",
     "@react-spring/three": "^9.4.5",
-    "@react-three/cannon": "^6.5.0",
+    "@react-three/cannon": "6.4.0",
     "@react-three/drei": "9.11.3",
     "@react-three/fiber": "^8.0.22",
     "@react-three/xr": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spacesvr",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "private": true,
   "description": "A standardized reality for future of the 3D Web",
   "keywords": [

--- a/src/layers/Environment/ui/PauseMenu/index.tsx
+++ b/src/layers/Environment/ui/PauseMenu/index.tsx
@@ -48,7 +48,7 @@ export default function PauseMenu(props: PauseMenuProps) {
   const PAUSE_ITEMS: PauseItem[] = [
     ...pauseMenuItems,
     {
-      text: "v2.5.2",
+      text: "v2.5.3",
       link: "https://www.npmjs.com/package/spacesvr",
     },
     ...menuItems,

--- a/src/layers/Player/colliders/CapsuleCollider.tsx
+++ b/src/layers/Player/colliders/CapsuleCollider.tsx
@@ -21,18 +21,14 @@ export const useCapsuleCollider = (pos = [0, 0, 0]) => {
 
   const { paused } = useEnvironment();
 
-  const compoundBody = useCompoundBody<Group>(
-    () => ({
-      mass: 0,
-      position: vPos.current,
-      segments: SEGMENTS,
-      fixedRotation: true,
-      type: "Dynamic",
-      shapes: [topSphere, middleSphere, bottomSphere],
-    }),
-    undefined,
-    []
-  );
+  const compoundBody = useCompoundBody<Group>(() => ({
+    mass: 0,
+    position: vPos.current,
+    segments: SEGMENTS,
+    fixedRotation: true,
+    type: "Dynamic",
+    shapes: [topSphere, middleSphere, bottomSphere],
+  }));
 
   useEffect(() => {
     if (!paused) compoundBody[1].mass.set(62);

--- a/src/layers/Player/utils/velocity.ts
+++ b/src/layers/Player/utils/velocity.ts
@@ -1,5 +1,5 @@
-import { useMemo, useRef } from "react";
-import { Camera, Group, MathUtils, Vector3 } from "three";
+import { useMemo, useRef, useState } from "react";
+import { Camera, Group, MathUtils, Quaternion, Vector3 } from "three";
 import { Api } from "@react-three/cannon";
 import { useEnvironment } from "../../Environment";
 
@@ -8,16 +8,18 @@ export const useSpringVelocity = (bodyApi: Api<Group>[1], speed: number) => {
   const { device } = useEnvironment();
   const dummy = useMemo(() => new Vector3(), []);
 
+  const [quat] = useState(new Quaternion());
+
   const updateVelocity = (cam: Camera, velocity: Vector3) => {
     // get forward/back movement and left/right movement velocities
     dummy.x = direction.current.x * 0.75;
     dummy.z = direction.current.y; // forward/back
     dummy.multiplyScalar(speed);
 
-    const moveQuaternion = cam.quaternion.clone();
-    moveQuaternion.x = 0;
-    moveQuaternion.z = 0;
-    dummy.applyQuaternion(moveQuaternion);
+    quat.copy(cam.quaternion);
+    quat.x = 0;
+    quat.z = 0;
+    dummy.applyQuaternion(quat);
     dummy.y = velocity.y;
 
     // keep y velocity intact and update velocity

--- a/src/logic/assets.ts
+++ b/src/logic/assets.ts
@@ -4,6 +4,8 @@ import { useThree } from "@react-three/fiber";
 import { useGLTF } from "@react-three/drei";
 import { suspend } from "suspend-react";
 import { useMemo } from "react";
+import { getFallbackModel, getFallbackTexture } from "./fallback";
+import { GLTF } from "three-stdlib";
 
 let ktx2loader: KTX2Loader | undefined;
 const KTX_CDN = "https://cdn.jsdelivr.net/gh/pmndrs/drei-assets@master/basis/";
@@ -15,7 +17,7 @@ const KTX_CDN = "https://cdn.jsdelivr.net/gh/pmndrs/drei-assets@master/basis/";
  * https://github.com/pmndrs/drei/blob/a2daf02853f624ef6062c70ba0b218bc03e5b626/src/core/useKTX2.tsx#L7
  * @param url
  */
-export function useImage(url: string) {
+export function useImage(url: string): Texture {
   const IS_KTX2 = url.toLowerCase().endsWith("ktx2");
   const gl = useThree((st) => st.gl);
 
@@ -31,10 +33,11 @@ export function useImage(url: string) {
 
   return suspend(
     (): Promise<CompressedTexture | Texture> =>
-      new Promise((res, reject) =>
-        loader.load(url, res, undefined, (error) =>
-          reject(new Error(`Could not load ${url}: ${error.message})`))
-        )
+      new Promise((res) =>
+        loader.load(url, res, undefined, (error) => {
+          console.error(error);
+          res(getFallbackTexture());
+        })
       ),
     [url]
   );
@@ -46,15 +49,22 @@ export function useImage(url: string) {
  * For all cases, functionality is to only download decoder files if needed by the file
  * @param url
  */
-export function useModel(url: string) {
+export function useModel(url: string): GLTF {
   const gl = useThree((st) => st.gl);
 
-  return useGLTF(url, true, true, (loader) => {
-    if (!ktx2loader) {
-      ktx2loader = new KTX2Loader();
-      ktx2loader.setTranscoderPath(KTX_CDN);
-      ktx2loader.detectSupport(gl);
-    }
-    loader.setKTX2Loader(ktx2loader);
-  });
+  try {
+    return useGLTF(url, true, true, (loader) => {
+      if (!ktx2loader) {
+        ktx2loader = new KTX2Loader();
+        ktx2loader.setTranscoderPath(KTX_CDN);
+        ktx2loader.detectSupport(gl);
+      }
+      loader.setKTX2Loader(ktx2loader);
+    });
+  } catch {
+    return suspend(
+      (): Promise<GLTF> => new Promise((res) => getFallbackModel().then(res)),
+      []
+    );
+  }
 }

--- a/src/logic/fallback.ts
+++ b/src/logic/fallback.ts
@@ -1,0 +1,89 @@
+import {
+  BoxBufferGeometry,
+  CanvasTexture,
+  Group,
+  Mesh,
+  MeshStandardMaterial,
+} from "three";
+import { GLTF } from "three-stdlib";
+import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader";
+import { GLTFExporter } from "three/examples/jsm/exporters/GLTFExporter";
+
+let fallbackTexture: CanvasTexture | undefined;
+
+const SIZE = 128;
+const SIZE_2 = SIZE / 2;
+const RAD = 12;
+const LINE_W = 1;
+
+/**
+ * Provides a default texture that is created locally
+ */
+export function getFallbackTexture(): CanvasTexture {
+  if (fallbackTexture) return fallbackTexture;
+
+  const canvas = document.createElement("canvas");
+  canvas.height = SIZE;
+  canvas.width = SIZE;
+
+  const context = canvas.getContext("2d") as CanvasRenderingContext2D;
+  context.fillStyle = "#FFFFFF";
+  context.fillRect(0, 0, SIZE, SIZE);
+
+  // main circle
+  context.fillStyle = "#000000";
+  context.beginPath();
+  context.arc(SIZE_2, SIZE_2, RAD, 0, 2 * Math.PI);
+  context.fill();
+
+  // draw a white line down the middle of the circle
+  context.strokeStyle = "#FFFFFF";
+  context.lineWidth = Math.ceil(LINE_W);
+  context.beginPath();
+  context.moveTo(SIZE_2, SIZE_2 - RAD);
+  context.lineTo(SIZE_2, SIZE_2 + RAD);
+  context.stroke();
+
+  // draw a horizontal line across the middle of the circle
+  context.beginPath();
+  context.moveTo(SIZE_2 - RAD, SIZE_2);
+  context.lineTo(SIZE_2 + RAD, SIZE_2);
+  context.stroke();
+
+  fallbackTexture = new CanvasTexture(canvas);
+
+  return fallbackTexture;
+}
+
+/**
+ * Provides a default model
+ */
+export function getFallbackModel(): Promise<GLTF> {
+  const group = new Group();
+  const geo = new BoxBufferGeometry(1, 1, 1);
+  const mat = new MeshStandardMaterial({ color: "black", wireframe: true });
+  const mesh = new Mesh(geo, mat);
+  group.add(mesh);
+
+  const exporter = new GLTFExporter();
+  const loader = new GLTFLoader();
+  return new Promise((res) =>
+    exporter.parse(
+      group,
+      (gltf) => {
+        loader.parse(
+          gltf as ArrayBuffer,
+          "",
+          // @ts-ignore
+          (gltf) => res(gltf as GLTF),
+          (err) => console.error(err)
+        );
+      },
+      {
+        binary: true,
+        embedImages: true,
+        onlyVisible: false,
+      }
+    )
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1235,7 +1235,7 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@pmndrs/cannon-worker-api@^2.3.0":
+"@pmndrs/cannon-worker-api@^2.1.0":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@pmndrs/cannon-worker-api/-/cannon-worker-api-2.3.0.tgz#5ef133833ef858a264d95fc70106ca567f113475"
   integrity sha512-XFR/IABU6uIEllocfGBV9SVakQWIYrZq/Ijk2ZYTv2jYorDebvT4cW8GWIE6UO/T/NChpI+fBTGlUs6wwZW5sg==
@@ -1286,12 +1286,12 @@
   resolved "https://registry.yarnpkg.com/@react-spring/types/-/types-9.4.5.tgz#9c71e5ff866b5484a7ef3db822bf6c10e77bdd8c"
   integrity sha512-mpRIamoHwql0ogxEUh9yr4TP0xU5CWyZxVQeccGkHHF8kPMErtDXJlxyo0lj+telRF35XNihtPTWoflqtyARmg==
 
-"@react-three/cannon@^6.5.0":
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/@react-three/cannon/-/cannon-6.5.0.tgz#72077716a5e51f37339134de261de5244d034787"
-  integrity sha512-C3ZC0bJwQAXQtvaNMURoVLISsbHfvASLhFmZSzseAfA6vEiza8RvcVsmByTPrKxF9udDpRmN9tQgtX6DA3deYg==
+"@react-three/cannon@6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@react-three/cannon/-/cannon-6.4.0.tgz#89aee95752c0f02caac04fa97675ccec59bd9b61"
+  integrity sha512-hrT7ploQOCKyP/vVSm9RWN2r2WPxjpTHDNnkxzwa/doK3IyREJ+40Ghor7E7pf76sjRgJFBrypVUSpKDcescTA==
   dependencies:
-    "@pmndrs/cannon-worker-api" "^2.3.0"
+    "@pmndrs/cannon-worker-api" "^2.1.0"
     cannon-es "^0.20.0"
     cannon-es-debugger "^1.0.0"
 


### PR DESCRIPTION
- revert to cannon 6.4.0, seems like update was buggy
- remove broken image urls from workshop
- provide fallbacks for `useImage` and `useModel` so failed requests don't error out
- slight performance fix