### PR TITLE
Cache Resources

### DIFF
--- a/src/ideas/index.ts
+++ b/src/ideas/index.ts
@@ -20,6 +20,8 @@ export * from "./modifiers/Floating";
 export * from "./modifiers/LookAtPlayer";
 export * from "./modifiers/Spinning";
 export * from "./modifiers/VisualEffect";
+export * from "./primitives/HitBox";
+export * from "./primitives/RoundedBox";
 export * from "./ui/Dialogue";
 export * from "./ui/TextInput";
 export * from "./ui/Arrow";

--- a/src/ideas/media/Model.tsx
+++ b/src/ideas/media/Model.tsx
@@ -1,6 +1,6 @@
 import { Suspense, useMemo } from "react";
 import { GroupProps } from "@react-three/fiber";
-import { useModel } from "../../logic";
+import { universe, useModel } from "../../logic";
 import { Box3, Vector3 } from "three";
 import { SkeletonUtils } from "three-stdlib";
 import { ErrorBoundary } from "react-error-boundary";
@@ -43,9 +43,8 @@ function FallbackModel(props: ModelProps) {
 
   return (
     <group name="spacesvr-fallback-model" {...rest}>
-      <mesh>
+      <mesh material={universe.mat_basic_black_wireframe}>
         <boxBufferGeometry args={[1, 1, 1]} />
-        <meshStandardMaterial color="black" wireframe />
       </mesh>
     </group>
   );

--- a/src/ideas/media/Model.tsx
+++ b/src/ideas/media/Model.tsx
@@ -1,6 +1,6 @@
 import { Suspense, useMemo } from "react";
 import { GroupProps } from "@react-three/fiber";
-import { universe, useModel } from "../../logic";
+import { cache, useModel } from "../../logic";
 import { Box3, Vector3 } from "three";
 import { SkeletonUtils } from "three-stdlib";
 import { ErrorBoundary } from "react-error-boundary";
@@ -43,7 +43,7 @@ function FallbackModel(props: ModelProps) {
 
   return (
     <group name="spacesvr-fallback-model" {...rest}>
-      <mesh material={universe.mat_basic_black_wireframe}>
+      <mesh material={cache.mat_basic_black_wireframe}>
         <boxBufferGeometry args={[1, 1, 1]} />
       </mesh>
     </group>

--- a/src/ideas/primitives/HitBox.tsx
+++ b/src/ideas/primitives/HitBox.tsx
@@ -1,0 +1,33 @@
+import { ColorRepresentation } from "three";
+import { Interactable, InteractableProps } from "../modifiers/Interactable";
+import { MeshProps } from "@react-three/fiber";
+
+type HitBox = {
+  args: [number, number, number];
+  visible?: boolean;
+  color?: ColorRepresentation;
+} & Omit<InteractableProps, "children"> &
+  Omit<MeshProps, "args">;
+
+export function HitBox(props: HitBox) {
+  const {
+    args,
+    visible = false,
+    color = "red",
+    onClick,
+    onHover,
+    onUnHover,
+    ...rest
+  } = props;
+
+  return (
+    <Interactable onClick={onClick} onHover={onHover} onUnHover={onUnHover}>
+      <mesh visible={visible} name="spacesvr-hitbox" {...rest}>
+        <boxBufferGeometry args={args} />
+        {visible && (
+          <meshBasicMaterial color={color} transparent opacity={0.7} />
+        )}
+      </mesh>
+    </Interactable>
+  );
+}

--- a/src/ideas/primitives/RoundedBox.tsx
+++ b/src/ideas/primitives/RoundedBox.tsx
@@ -1,35 +1,7 @@
-import { universe } from "../../logic/universe";
+import { cache } from "../../logic/cache";
 import { NamedArrayTuple } from "@react-three/drei/helpers/ts-utils";
 import { useMemo } from "react";
 import { RoundedBoxGeometry } from "three/examples/jsm/geometries/RoundedBoxGeometry";
-
-type CachedBox = {
-  width: number;
-  height: number;
-  depth: number;
-  key: keyof typeof universe;
-};
-
-const CACHED_BOXES: CachedBox[] = [
-  {
-    width: 1,
-    height: 1,
-    depth: 0.25,
-    key: "geo_rounded_box_1x1",
-  },
-  {
-    width: 1,
-    height: 0.35,
-    depth: 0.125,
-    key: "geo_rounded_box_1x0_35",
-  },
-  {
-    width: 1,
-    height: 0.3,
-    depth: 0.1,
-    key: "geo_rounded_box_1x0_3",
-  },
-];
 
 type RoundedBox = {
   args?: NamedArrayTuple<
@@ -45,12 +17,12 @@ export function RoundedBox(props: RoundedBox) {
   } = props;
 
   const geo = useMemo(() => {
-    const tolerance = 0.25; // 15% tolerance
+    const tolerance = 0.25; // 25% tolerance
 
     let closestBox = undefined;
     let closestOffset = Infinity;
     for (const box of CACHED_BOXES) {
-      const scale = width / box.width;
+      const scale = box.width / width;
       const heightDiff = Math.abs(box.height - height * scale);
       const depthDiff = Math.abs(box.depth - depth * scale);
       if (
@@ -64,7 +36,7 @@ export function RoundedBox(props: RoundedBox) {
     }
 
     if (closestBox) {
-      return (universe[closestBox.key] as RoundedBoxGeometry)
+      return (cache[closestBox.key] as RoundedBoxGeometry)
         .clone()
         .scale(
           width / closestBox.width,
@@ -85,3 +57,55 @@ export function RoundedBox(props: RoundedBox) {
     </group>
   );
 }
+
+type CachedBox = {
+  width: number;
+  height: number;
+  depth: number;
+  key: keyof typeof cache;
+};
+
+const CACHED_BOXES: CachedBox[] = [
+  {
+    width: 1,
+    height: 1,
+    depth: 0.25,
+    key: "geo_rounded_box_1x1x0_25",
+  },
+  {
+    width: 1,
+    height: 0.35,
+    depth: 0.125,
+    key: "geo_rounded_box_1x0_35x0_125",
+  },
+  {
+    width: 1,
+    height: 0.3,
+    depth: 0.1,
+    key: "geo_rounded_box_1x0_3x0_1",
+  },
+  {
+    width: 1,
+    height: 0.19,
+    depth: 0.23,
+    key: "geo_rounded_box_1x0_19x0_23",
+  },
+  {
+    width: 1,
+    height: 0.44,
+    depth: 0.23,
+    key: "geo_rounded_box_1x0_44x0_23",
+  },
+  {
+    width: 1,
+    height: 0.11,
+    depth: 0.06,
+    key: "geo_rounded_box_1x0_11x0_06",
+  },
+  {
+    width: 1,
+    height: 0.13,
+    depth: 0.04,
+    key: "geo_rounded_box_1x0_13x0_04",
+  },
+];

--- a/src/ideas/primitives/RoundedBox.tsx
+++ b/src/ideas/primitives/RoundedBox.tsx
@@ -50,11 +50,9 @@ export function RoundedBox(props: RoundedBox) {
   }, [width, height, depth]);
 
   return (
-    <group name="spacesvr-rounded-box">
-      <mesh {...rest} geometry={geo}>
-        {children}
-      </mesh>
-    </group>
+    <mesh name="spacesvr-rounded-box" {...rest} geometry={geo}>
+      {children}
+    </mesh>
   );
 }
 

--- a/src/ideas/primitives/RoundedBox.tsx
+++ b/src/ideas/primitives/RoundedBox.tsx
@@ -1,0 +1,87 @@
+import { universe } from "../../logic/universe";
+import { NamedArrayTuple } from "@react-three/drei/helpers/ts-utils";
+import { useMemo } from "react";
+import { RoundedBoxGeometry } from "three/examples/jsm/geometries/RoundedBoxGeometry";
+
+type CachedBox = {
+  width: number;
+  height: number;
+  depth: number;
+  key: keyof typeof universe;
+};
+
+const CACHED_BOXES: CachedBox[] = [
+  {
+    width: 1,
+    height: 1,
+    depth: 0.25,
+    key: "geo_rounded_box_1x1",
+  },
+  {
+    width: 1,
+    height: 0.35,
+    depth: 0.125,
+    key: "geo_rounded_box_1x0_35",
+  },
+  {
+    width: 1,
+    height: 0.3,
+    depth: 0.1,
+    key: "geo_rounded_box_1x0_3",
+  },
+];
+
+type RoundedBox = {
+  args?: NamedArrayTuple<
+    (width?: number, height?: number, depth?: number) => void
+  >;
+} & Omit<JSX.IntrinsicElements["mesh"], "args">;
+
+export function RoundedBox(props: RoundedBox) {
+  const {
+    args: [width = 1, height = 1, depth = 0.25] = [],
+    children,
+    ...rest
+  } = props;
+
+  const geo = useMemo(() => {
+    const tolerance = 0.25; // 15% tolerance
+
+    let closestBox = undefined;
+    let closestOffset = Infinity;
+    for (const box of CACHED_BOXES) {
+      const scale = width / box.width;
+      const heightDiff = Math.abs(box.height - height * scale);
+      const depthDiff = Math.abs(box.depth - depth * scale);
+      if (
+        heightDiff / box.height < tolerance &&
+        depthDiff / box.depth < tolerance &&
+        heightDiff + depthDiff < closestOffset
+      ) {
+        closestBox = box;
+        closestOffset = heightDiff + depthDiff;
+      }
+    }
+
+    if (closestBox) {
+      return (universe[closestBox.key] as RoundedBoxGeometry)
+        .clone()
+        .scale(
+          width / closestBox.width,
+          height / closestBox.height,
+          depth / closestBox.depth
+        );
+    }
+
+    const radius = Math.min(width, height, depth) / 2;
+    return new RoundedBoxGeometry(width, height, depth, 4, radius);
+  }, [width, height, depth]);
+
+  return (
+    <group name="spacesvr-rounded-box">
+      <mesh {...rest} geometry={geo}>
+        {children}
+      </mesh>
+    </group>
+  );
+}

--- a/src/ideas/ui/Arrow.tsx
+++ b/src/ideas/ui/Arrow.tsx
@@ -1,5 +1,7 @@
 import { GroupProps } from "@react-three/fiber";
 import { useImage } from "../../logic/assets";
+import { cache } from "../../logic";
+import { MeshStandardMaterial } from "three";
 
 type ArrowProps = { dark?: boolean } & GroupProps;
 
@@ -12,15 +14,20 @@ export function Arrow(props: ArrowProps) {
 
   const texture = useImage(dark ? IMAGE_SRC_DARK : IMAGE_SRC);
 
+  const arrowMat = cache.useResource(
+    `spacesvr_arrow_${dark ? "dark" : "light"}`,
+    () =>
+      new MeshStandardMaterial({
+        map: texture,
+        alphaTest: 0.5,
+        transparent: true,
+      })
+  );
+
   return (
     <group name="spacesvr-arrow" {...rest}>
-      <mesh scale={0.004}>
+      <mesh scale={0.004} material={arrowMat}>
         <planeBufferGeometry args={[98, 51]} />
-        <meshStandardMaterial
-          map={texture}
-          alphaTest={0.5}
-          transparent={true}
-        />
       </mesh>
     </group>
   );

--- a/src/ideas/ui/Button.tsx
+++ b/src/ideas/ui/Button.tsx
@@ -1,10 +1,11 @@
-import { RoundedBox, Text } from "@react-three/drei";
+import { Text } from "@react-three/drei";
 import { animated, config, useSpring } from "@react-spring/three";
 import { GroupProps } from "@react-three/fiber";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Interactable } from "../modifiers/Interactable";
 import { Idea } from "../../logic/basis/idea";
 import { Color, Raycaster } from "three";
+import { RoundedBox } from "../primitives/RoundedBox";
 
 type ButtonProps = {
   children?: string;
@@ -95,7 +96,6 @@ export function Button(props: ButtonProps) {
   const HEIGHT = dims[1] + PADDING;
   const DEPTH = fontSize * 1.1;
   const OUTLINE_WIDTH = outline ? fontSize * 0.075 : 0;
-  const RADIUS = Math.min(WIDTH, HEIGHT, DEPTH) * 0.5;
 
   return (
     <group name={`spacesvr-button-${children}`} {...rest}>
@@ -125,11 +125,7 @@ export function Button(props: ButtonProps) {
             <boxBufferGeometry args={[WIDTH, HEIGHT, DEPTH]} />
           </mesh>
         </Interactable>
-        <RoundedBox
-          args={[WIDTH, HEIGHT, DEPTH]}
-          radius={RADIUS}
-          smoothness={6}
-        >
+        <RoundedBox args={[WIDTH, HEIGHT, DEPTH]}>
           {/* @ts-ignore */}
           <animated.meshStandardMaterial color={animColor} />
         </RoundedBox>

--- a/src/ideas/ui/Button.tsx
+++ b/src/ideas/ui/Button.tsx
@@ -2,10 +2,10 @@ import { Text } from "@react-three/drei";
 import { animated, config, useSpring } from "@react-spring/three";
 import { GroupProps } from "@react-three/fiber";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { Interactable } from "../modifiers/Interactable";
 import { Idea } from "../../logic/basis/idea";
 import { Color, Raycaster } from "three";
 import { RoundedBox } from "../primitives/RoundedBox";
+import { HitBox } from "../primitives/HitBox";
 
 type ButtonProps = {
   children?: string;
@@ -115,16 +115,13 @@ export function Button(props: ButtonProps) {
         >
           {children}
         </Text>
-        <Interactable
+        <HitBox
+          args={[WIDTH, HEIGHT, DEPTH]}
           onClick={onButtonClick}
           onHover={() => setHovered(true)}
           onUnHover={() => setHovered(false)}
           raycaster={raycaster}
-        >
-          <mesh visible={false} name="hitbox">
-            <boxBufferGeometry args={[WIDTH, HEIGHT, DEPTH]} />
-          </mesh>
-        </Interactable>
+        />
         <RoundedBox args={[WIDTH, HEIGHT, DEPTH]}>
           {/* @ts-ignore */}
           <animated.meshStandardMaterial color={animColor} />

--- a/src/ideas/ui/Dialogue/ideas/Bubbles.tsx
+++ b/src/ideas/ui/Dialogue/ideas/Bubbles.tsx
@@ -39,7 +39,7 @@ export default function Bubbles(props: BubblesProps) {
     for (let i = 0; i < numStops; i++) {
       const perc = i / (numStops - 1);
       obj.position.set(perc * pos.x, perc * pos.y, perc * pos.z);
-      const sc = 0.01 + perc * 0.05;
+      const sc = 0.8 + perc * 4;
       const delay = 60 / 1000;
       const time = 400 / 1000;
       const delta = clock.elapsedTime - startTime.current;
@@ -55,8 +55,8 @@ export default function Bubbles(props: BubblesProps) {
     mesh.current.instanceMatrix.needsUpdate = true;
   });
 
-  const geo = useMemo(() => new SphereBufferGeometry(4, 32, 16), []);
-  const mat = useIdeaMaterial(undefined, 4);
+  const geo = useMemo(() => new SphereBufferGeometry(0.05, 32, 16), []);
+  const mat = useIdeaMaterial(undefined, 0.05);
 
   return (
     <>

--- a/src/ideas/ui/Dialogue/index.tsx
+++ b/src/ideas/ui/Dialogue/index.tsx
@@ -1,13 +1,13 @@
 import { GroupProps } from "@react-three/fiber";
 import { useRef, useState } from "react";
-import { DoubleSide, Group } from "three";
-import { RoundedBox } from "@react-three/drei";
+import { Group } from "three";
 import { animated, useSpring } from "@react-spring/three";
 import { useLimitedFrame } from "../../../logic/limiter";
 import { DialogueFSM } from "./logic/types";
 import Bubbles from "./ideas/Bubbles";
 import VisualInteraction from "./ideas/VisualInteraction";
 import { FacePlayer } from "../../modifiers/FacePlayer";
+import { universe } from "../../../logic/universe";
 export * from "./logic/types";
 
 type DialogueProps = {
@@ -49,7 +49,6 @@ export function Dialogue(props: DialogueProps) {
   const HEIGHT = 0.35;
   const DEPTH = 0.125;
   const POS_X = side === "right" ? WIDTH / 2 : -WIDTH / 2;
-  const RADIUS = Math.min(WIDTH, HEIGHT, DEPTH) * 0.5;
 
   return (
     <group name="dialogue" {...rest}>
@@ -58,13 +57,10 @@ export function Dialogue(props: DialogueProps) {
         <group name="main-dialogue" position={offset}>
           <group name="look-at" ref={group}>
             <animated.group scale={scale} position-x={POS_X}>
-              <RoundedBox
-                args={[WIDTH, HEIGHT, DEPTH]}
-                radius={RADIUS}
-                smoothness={6}
-              >
-                <meshStandardMaterial color="#aaa" side={DoubleSide} />
-              </RoundedBox>
+              <mesh
+                geometry={universe.geo_rounded_box_1x0_35}
+                material={universe.mat_standard_cream_double}
+              />
               <group name="interactions" position-z={DEPTH / 2 + 0.003}>
                 {dialogue.map((interaction) => (
                   <VisualInteraction

--- a/src/ideas/ui/Dialogue/index.tsx
+++ b/src/ideas/ui/Dialogue/index.tsx
@@ -7,7 +7,8 @@ import { DialogueFSM } from "./logic/types";
 import Bubbles from "./ideas/Bubbles";
 import VisualInteraction from "./ideas/VisualInteraction";
 import { FacePlayer } from "../../modifiers/FacePlayer";
-import { universe } from "../../../logic/universe";
+import { cache } from "../../../logic/cache";
+import { RoundedBox } from "../../primitives/RoundedBox";
 export * from "./logic/types";
 
 type DialogueProps = {
@@ -57,9 +58,9 @@ export function Dialogue(props: DialogueProps) {
         <group name="main-dialogue" position={offset}>
           <group name="look-at" ref={group}>
             <animated.group scale={scale} position-x={POS_X}>
-              <mesh
-                geometry={universe.geo_rounded_box_1x0_35}
-                material={universe.mat_standard_cream_double}
+              <RoundedBox
+                args={[WIDTH, HEIGHT, DEPTH]}
+                material={cache.mat_standard_cream_double}
               />
               <group name="interactions" position-z={DEPTH / 2 + 0.003}>
                 {dialogue.map((interaction) => (

--- a/src/ideas/ui/Dialogue/logic/ideaMat.ts
+++ b/src/ideas/ui/Dialogue/logic/ideaMat.ts
@@ -11,8 +11,8 @@ export const useIdeaMaterial = (idea: Idea | undefined, radius: number) => {
 
   const { col } = useSpring({ col: hex });
 
-  const NOISE_AMPLITUDE = 0.82;
-  const NOISE_FREQ = 0.154;
+  const NOISE_AMPLITUDE = radius * 0.32;
+  const NOISE_FREQ = 0.554 / radius;
 
   const mat = useMemo(() => {
     const material = new MeshStandardMaterial({

--- a/src/ideas/ui/Key.tsx
+++ b/src/ideas/ui/Key.tsx
@@ -1,7 +1,8 @@
 import { GroupProps } from "@react-three/fiber";
-import { RoundedBox, Text } from "@react-three/drei";
+import { Text } from "@react-three/drei";
 import { animated, config, useSpring } from "@react-spring/three";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
+import { universe } from "../../logic";
 
 type Props = {
   keyCode: string;
@@ -54,15 +55,13 @@ export function Key(props: Props) {
       <group position-z={-DEPTH}>
         <animated.group scale-z={scale}>
           <group position-z={DEPTH / 2}>
-            <RoundedBox
-              args={[1, 1, DEPTH]}
-              radius={DEPTH * 0.5}
+            <mesh
+              geometry={universe.geo_rounded_box_1x1}
               position-z={-DEPTH / 2 - 0.01}
-              smoothness={10}
             >
               {/* @ts-ignore */}
               <animated.meshStandardMaterial color={color} />
-            </RoundedBox>
+            </mesh>
             <Text color="black" fontSize={0.5} renderOrder={2}>
               {keyCode}
             </Text>

--- a/src/ideas/ui/Key.tsx
+++ b/src/ideas/ui/Key.tsx
@@ -2,7 +2,7 @@ import { GroupProps } from "@react-three/fiber";
 import { Text } from "@react-three/drei";
 import { animated, config, useSpring } from "@react-spring/three";
 import { useEffect, useState } from "react";
-import { universe } from "../../logic";
+import { RoundedBox } from "../primitives/RoundedBox";
 
 type Props = {
   keyCode: string;
@@ -55,13 +55,10 @@ export function Key(props: Props) {
       <group position-z={-DEPTH}>
         <animated.group scale-z={scale}>
           <group position-z={DEPTH / 2}>
-            <mesh
-              geometry={universe.geo_rounded_box_1x1}
-              position-z={-DEPTH / 2 - 0.01}
-            >
+            <RoundedBox args={[1, 1, DEPTH]} position-z={-DEPTH / 2 - 0.01}>
               {/* @ts-ignore */}
               <animated.meshStandardMaterial color={color} />
-            </mesh>
+            </RoundedBox>
             <Text color="black" fontSize={0.5} renderOrder={2}>
               {keyCode}
             </Text>

--- a/src/ideas/ui/Switch.tsx
+++ b/src/ideas/ui/Switch.tsx
@@ -1,11 +1,12 @@
 import { animated, useSpring } from "@react-spring/three";
 import { VisualIdea } from "../basis/VisualIdea";
-import { RoundedBox } from "@react-three/drei";
+import { RoundedBox } from "../primitives/RoundedBox";
 import { GroupProps } from "@react-three/fiber";
 import { Raycaster } from "three";
 import { Interactable } from "../modifiers/Interactable";
 import { Idea } from "../../logic/basis/idea";
 import { useState } from "react";
+import { universe } from "../../logic/universe";
 
 type SwitchProps = {
   value?: boolean;
@@ -33,7 +34,6 @@ export function Switch(props: SwitchProps) {
   const OUTER_WIDTH = WIDTH + BORDER * 2;
   const OUTER_HEIGHT = HEIGHT + BORDER;
   const KNOB_SIZE = SIZE * 0.8;
-  const RADIUS = Math.min(WIDTH, HEIGHT, DEPTH) * 0.5;
 
   const { posX, knobColor } = useSpring({
     posX: val ? WIDTH / 2 : -WIDTH / 2,
@@ -41,8 +41,8 @@ export function Switch(props: SwitchProps) {
     config: { mass: 0.1 },
   });
 
-  const [onIdea] = useState(new Idea().setFromCreation(0, 0, 1));
-  const [offIdea] = useState(new Idea().setFromCreation(0, 0, 0.75));
+  const [onIdea] = useState(new Idea(0, 0, 1));
+  const [offIdea] = useState(new Idea(0, 0, 0.75));
 
   return (
     <group name="spacesvr-switch-input" {...rest}>
@@ -50,22 +50,15 @@ export function Switch(props: SwitchProps) {
         <animated.group position-x={posX}>
           <VisualIdea scale={KNOB_SIZE} idea={val ? onIdea : offIdea} />
         </animated.group>
-        <RoundedBox
-          args={[WIDTH, HEIGHT, DEPTH]}
-          smoothness={8}
-          radius={RADIUS}
-        >
+        <RoundedBox args={[WIDTH, HEIGHT, DEPTH]}>
           {/* @ts-ignore */}
           <animated.meshBasicMaterial color={knobColor} />
         </RoundedBox>
         <RoundedBox
           args={[OUTER_WIDTH, OUTER_HEIGHT, DEPTH]}
-          radius={RADIUS}
-          smoothness={8}
+          material={universe.mat_basic_gray}
           position-z={-0.001}
-        >
-          <animated.meshBasicMaterial color="#828282" />
-        </RoundedBox>
+        />
       </Interactable>
     </group>
   );

--- a/src/ideas/ui/Switch.tsx
+++ b/src/ideas/ui/Switch.tsx
@@ -3,10 +3,10 @@ import { VisualIdea } from "../basis/VisualIdea";
 import { RoundedBox } from "../primitives/RoundedBox";
 import { GroupProps } from "@react-three/fiber";
 import { Raycaster } from "three";
-import { Interactable } from "../modifiers/Interactable";
 import { Idea } from "../../logic/basis/idea";
 import { useState } from "react";
-import { universe } from "../../logic/universe";
+import { cache } from "../../logic/cache";
+import { HitBox } from "../primitives/HitBox";
 
 type SwitchProps = {
   value?: boolean;
@@ -46,20 +46,27 @@ export function Switch(props: SwitchProps) {
 
   return (
     <group name="spacesvr-switch-input" {...rest}>
-      <Interactable onClick={() => setVal(!val)} raycaster={passedRaycaster}>
-        <animated.group position-x={posX}>
-          <VisualIdea scale={KNOB_SIZE} idea={val ? onIdea : offIdea} />
-        </animated.group>
-        <RoundedBox args={[WIDTH, HEIGHT, DEPTH]}>
-          {/* @ts-ignore */}
-          <animated.meshBasicMaterial color={knobColor} />
-        </RoundedBox>
-        <RoundedBox
-          args={[OUTER_WIDTH, OUTER_HEIGHT, DEPTH]}
-          material={universe.mat_basic_gray}
-          position-z={-0.001}
-        />
-      </Interactable>
+      <animated.group position-x={posX}>
+        <VisualIdea scale={KNOB_SIZE} idea={val ? onIdea : offIdea} />
+      </animated.group>
+      <HitBox
+        args={[KNOB_SIZE, KNOB_SIZE, KNOB_SIZE]}
+        onClick={() => setVal(!val)}
+        position-x={val ? WIDTH / 2 : -WIDTH / 2}
+      />
+      <HitBox
+        args={[OUTER_WIDTH, OUTER_HEIGHT, DEPTH]}
+        onClick={() => setVal(!val)}
+      />
+      <RoundedBox args={[WIDTH, HEIGHT, DEPTH]}>
+        {/* @ts-ignore */}
+        <animated.meshBasicMaterial color={knobColor} />
+      </RoundedBox>
+      <RoundedBox
+        args={[OUTER_WIDTH, OUTER_HEIGHT, DEPTH]}
+        material={cache.mat_basic_gray}
+        position-z={-0.001}
+      />
     </group>
   );
 }

--- a/src/ideas/ui/TextInput/index.tsx
+++ b/src/ideas/ui/TextInput/index.tsx
@@ -1,12 +1,13 @@
 import { useRef, Suspense, useState, useCallback, useEffect } from "react";
-import { RoundedBox, Text } from "@react-three/drei";
+import { Text } from "@react-three/drei";
+import { RoundedBox } from "../../primitives/RoundedBox";
 import { GroupProps, useThree } from "@react-three/fiber";
 import { animated, useSpring } from "@react-spring/three";
 import { useTextInput } from "../../../logic/input";
 import { Interactable } from "../../modifiers/Interactable";
 import { useKeypress, useShiftHold } from "../../../logic/keys";
 import { usePlayer } from "../../../layers/Player";
-import { Mesh, Raycaster } from "three";
+import { Mesh, MeshStandardMaterial, Raycaster } from "three";
 import { syncOnChange } from "./logic/sync";
 import {
   getClickedCaret,
@@ -17,6 +18,14 @@ import {
 import { useCaretBlink } from "./logic/blink";
 import { useDragSelect } from "./logic/drag";
 import { useLimitedFrame } from "../../../logic/limiter";
+import { universe } from "../../../logic/universe";
+
+const highlightMat = new MeshStandardMaterial({
+  color: "blue",
+  transparent: true,
+  opacity: 0.3,
+  depthWrite: false,
+});
 
 type TextProps = {
   value?: string;
@@ -90,7 +99,6 @@ export function TextInput(props: TextProps) {
   const OUTER_WIDTH = width + BORDER * 2;
 
   const DEPTH = fontSize * 0.5;
-  const RADIUS = Math.min(INPUT_WIDTH, INPUT_HEIGHT, DEPTH) * 0.5;
 
   const shift = useShiftHold();
   const lastClickTime = useRef(0);
@@ -329,36 +337,31 @@ export function TextInput(props: TextProps) {
           </Text>
         </Suspense>
         <group name="blink" ref={blink.blinkRef}>
-          <mesh name="caret" ref={caret} visible={false}>
+          <mesh
+            name="caret"
+            ref={caret}
+            visible={false}
+            material={universe.mat_basic_black}
+          >
             <planeBufferGeometry args={[0.075 * fontSize, fontSize]} />
-            <meshBasicMaterial color="black" />
           </mesh>
         </group>
-        <mesh name="highlight" ref={highlight} visible={false}>
+        <mesh
+          name="highlight"
+          ref={highlight}
+          visible={false}
+          material={highlightMat}
+        >
           <boxBufferGeometry args={[1, fontSize, DEPTH * 0.45]} />
-          <meshStandardMaterial
-            color="blue"
-            transparent
-            opacity={0.3}
-            depthWrite={false}
-          />
         </mesh>
       </group>
       <Interactable onClick={registerClick} raycaster={RAYCASTER}>
         <RoundedBox
           args={[INPUT_WIDTH, INPUT_HEIGHT, DEPTH]}
-          radius={RADIUS}
-          smoothness={6}
-        >
-          <meshStandardMaterial color="white" />
-        </RoundedBox>
+          material={universe.mat_standard_white}
+        />
       </Interactable>
-      <RoundedBox
-        args={[OUTER_WIDTH, OUTER_HEIGHT, DEPTH]}
-        radius={RADIUS}
-        smoothness={6}
-        position-z={-0.001}
-      >
+      <RoundedBox args={[OUTER_WIDTH, OUTER_HEIGHT, DEPTH]} position-z={-0.001}>
         {/* @ts-ignore */}
         <animated.meshStandardMaterial color={color} />
       </RoundedBox>

--- a/src/ideas/ui/TextInput/index.tsx
+++ b/src/ideas/ui/TextInput/index.tsx
@@ -4,7 +4,6 @@ import { RoundedBox } from "../../primitives/RoundedBox";
 import { GroupProps, useThree } from "@react-three/fiber";
 import { animated, useSpring } from "@react-spring/three";
 import { useTextInput } from "../../../logic/input";
-import { Interactable } from "../../modifiers/Interactable";
 import { useKeypress, useShiftHold } from "../../../logic/keys";
 import { usePlayer } from "../../../layers/Player";
 import { Mesh, MeshStandardMaterial, Raycaster } from "three";
@@ -18,14 +17,8 @@ import {
 import { useCaretBlink } from "./logic/blink";
 import { useDragSelect } from "./logic/drag";
 import { useLimitedFrame } from "../../../logic/limiter";
-import { universe } from "../../../logic/universe";
-
-const highlightMat = new MeshStandardMaterial({
-  color: "blue",
-  transparent: true,
-  opacity: 0.3,
-  depthWrite: false,
-});
+import { cache } from "../../../logic/cache";
+import { HitBox } from "../../primitives/HitBox";
 
 type TextProps = {
   value?: string;
@@ -87,6 +80,17 @@ export function TextInput(props: TextProps) {
   }, [input, onBlur]);
 
   const { color } = useSpring({ color: focused ? "#000" : "#828282" });
+
+  const highlightMat = cache.useResource(
+    "spacesvr_textinput_highlight",
+    () =>
+      new MeshStandardMaterial({
+        color: "blue",
+        transparent: true,
+        opacity: 0.3,
+        depthWrite: false,
+      })
+  );
 
   const BORDER = fontSize * 0.1;
   const PADDING_X = fontSize * 0.5;
@@ -341,7 +345,7 @@ export function TextInput(props: TextProps) {
             name="caret"
             ref={caret}
             visible={false}
-            material={universe.mat_basic_black}
+            material={cache.mat_basic_black}
           >
             <planeBufferGeometry args={[0.075 * fontSize, fontSize]} />
           </mesh>
@@ -355,12 +359,15 @@ export function TextInput(props: TextProps) {
           <boxBufferGeometry args={[1, fontSize, DEPTH * 0.45]} />
         </mesh>
       </group>
-      <Interactable onClick={registerClick} raycaster={RAYCASTER}>
-        <RoundedBox
-          args={[INPUT_WIDTH, INPUT_HEIGHT, DEPTH]}
-          material={universe.mat_standard_white}
-        />
-      </Interactable>
+      <HitBox
+        args={[INPUT_WIDTH, INPUT_HEIGHT, DEPTH]}
+        raycaster={RAYCASTER}
+        onClick={registerClick}
+      />
+      <RoundedBox
+        args={[INPUT_WIDTH, INPUT_HEIGHT, DEPTH]}
+        material={cache.mat_standard_white}
+      />
       <RoundedBox args={[OUTER_WIDTH, OUTER_HEIGHT, DEPTH]} position-z={-0.001}>
         {/* @ts-ignore */}
         <animated.meshStandardMaterial color={color} />

--- a/src/logic/cache.ts
+++ b/src/logic/cache.ts
@@ -1,18 +1,40 @@
 import { DoubleSide, MeshBasicMaterial, MeshStandardMaterial } from "three";
 import { RoundedBoxGeometry } from "three/examples/jsm/geometries/RoundedBoxGeometry";
+import { useEffect, useState } from "react";
 
-const universe_cache = new Map();
+const universe_cache = new Map<string, any>();
 
-function getResource<T = any>(key: string, constructor: () => T) {
+function getResource<T = any>(
+  key: string,
+  constructor: () => T,
+  opts?: { verbose?: boolean }
+) {
   let resource = universe_cache.get(key);
   if (!resource) {
+    if (opts?.verbose) console.log(`[CACHE] ${key} not found, creating new`);
     resource = constructor();
     universe_cache.set(key, resource);
+  } else {
+    if (opts?.verbose) console.log(`[CACHE] ${key} found, returning`);
   }
   return resource;
 }
 
-export const universe = {
+export const cache = {
+  getResource,
+  useResource: <T = any>(
+    key: string,
+    constructor: () => T,
+    opts?: { verbose?: boolean }
+  ) => {
+    const [resource, setResource] = useState<T>(
+      getResource(key, constructor, opts)
+    );
+    useEffect(() => {
+      setResource(getResource(key, constructor, opts));
+    }, [key]);
+    return resource;
+  },
   get mat_standard_white(): MeshStandardMaterial {
     return getResource<MeshStandardMaterial>(
       "mat_standard_white",
@@ -61,22 +83,46 @@ export const universe = {
       () => new MeshBasicMaterial({ color: "black", wireframe: true })
     );
   },
-  get geo_rounded_box_1x1(): RoundedBoxGeometry {
+  get geo_rounded_box_1x1x0_25(): RoundedBoxGeometry {
     return getResource<RoundedBoxGeometry>(
-      "geo_rounded_box_1x1",
+      "geo_rounded_box_1x1x0_25",
       () => new RoundedBoxGeometry(1, 1, 0.25, 4, 0.125)
     );
   },
-  get geo_rounded_box_1x0_35(): RoundedBoxGeometry {
+  get geo_rounded_box_1x0_35x0_125(): RoundedBoxGeometry {
     return getResource<RoundedBoxGeometry>(
-      "geo_rounded_box_1x0_35",
+      "geo_rounded_box_1x0_35x0_125",
       () => new RoundedBoxGeometry(1, 0.35, 0.125, 4, 0.0625)
     );
   },
-  get geo_rounded_box_1x0_3(): RoundedBoxGeometry {
+  get geo_rounded_box_1x0_3x0_1(): RoundedBoxGeometry {
     return getResource<RoundedBoxGeometry>(
-      "geo_rounded_box_1x0_3",
+      "geo_rounded_box_1x0_3x0_1",
       () => new RoundedBoxGeometry(1, 0.3, 0.1, 4, 0.05)
+    );
+  },
+  get geo_rounded_box_1x0_19x0_23(): RoundedBoxGeometry {
+    return getResource<RoundedBoxGeometry>(
+      "geo_rounded_box_1x0_19x0_23",
+      () => new RoundedBoxGeometry(1, 0.19, 0.23, 4, 0.095)
+    );
+  },
+  get geo_rounded_box_1x0_44x0_23(): RoundedBoxGeometry {
+    return getResource<RoundedBoxGeometry>(
+      "geo_rounded_box_1x0_44x0_23",
+      () => new RoundedBoxGeometry(1, 0.44, 0.23, 4, 0.115)
+    );
+  },
+  get geo_rounded_box_1x0_11x0_06(): RoundedBoxGeometry {
+    return getResource<RoundedBoxGeometry>(
+      "geo_rounded_box_1x0_11x0_06",
+      () => new RoundedBoxGeometry(1, 0.11, 0.06, 4, 0.03)
+    );
+  },
+  get geo_rounded_box_1x0_13x0_04(): RoundedBoxGeometry {
+    return getResource<RoundedBoxGeometry>(
+      "geo_rounded_box_1x0_13x0_04",
+      () => new RoundedBoxGeometry(1, 0.13, 0.04, 4, 0.02)
     );
   },
 };

--- a/src/logic/index.ts
+++ b/src/logic/index.ts
@@ -10,4 +10,5 @@ export * from "./keyboard";
 export * from "./keys";
 export * from "./limiter";
 export * from "./rerender";
+export * from "./universe";
 export * from "./visible";

--- a/src/logic/index.ts
+++ b/src/logic/index.ts
@@ -1,6 +1,7 @@
 export * from "./basis";
 export * from "./assets";
 export * from "./bvh";
+export * from "./cache";
 export * from "./collision";
 export * from "./dom";
 export * from "./drag";
@@ -10,5 +11,4 @@ export * from "./keyboard";
 export * from "./keys";
 export * from "./limiter";
 export * from "./rerender";
-export * from "./universe";
 export * from "./visible";

--- a/src/logic/universe.ts
+++ b/src/logic/universe.ts
@@ -1,0 +1,82 @@
+import { DoubleSide, MeshBasicMaterial, MeshStandardMaterial } from "three";
+import { RoundedBoxGeometry } from "three/examples/jsm/geometries/RoundedBoxGeometry";
+
+const universe_cache = new Map();
+
+function getResource<T = any>(key: string, constructor: () => T) {
+  let resource = universe_cache.get(key);
+  if (!resource) {
+    resource = constructor();
+    universe_cache.set(key, resource);
+  }
+  return resource;
+}
+
+export const universe = {
+  get mat_standard_white(): MeshStandardMaterial {
+    return getResource<MeshStandardMaterial>(
+      "mat_standard_white",
+      () => new MeshStandardMaterial({ color: "white" })
+    );
+  },
+  get mat_standard_cream_double(): MeshStandardMaterial {
+    return getResource<MeshStandardMaterial>(
+      "mat_standard_cream_double",
+      () => new MeshStandardMaterial({ color: "#aaa", side: DoubleSide })
+    );
+  },
+  get mat_standard_black(): MeshStandardMaterial {
+    return getResource<MeshStandardMaterial>(
+      "mat_standard_black",
+      () => new MeshStandardMaterial({ color: "black" })
+    );
+  },
+  get mat_standard_rose(): MeshStandardMaterial {
+    return getResource<MeshStandardMaterial>(
+      "mat_standard_rose",
+      () => new MeshStandardMaterial({ color: "#ff007f" })
+    );
+  },
+  get mat_basic_black(): MeshBasicMaterial {
+    return getResource<MeshBasicMaterial>(
+      "mat_basic_black",
+      () => new MeshBasicMaterial({ color: "black" })
+    );
+  },
+  get mat_basic_gray(): MeshBasicMaterial {
+    return getResource<MeshBasicMaterial>(
+      "mat_basic_gray",
+      () => new MeshBasicMaterial({ color: "#828282" })
+    );
+  },
+  get mat_basic_red(): MeshBasicMaterial {
+    return getResource<MeshBasicMaterial>(
+      "mat_basic_red",
+      () => new MeshBasicMaterial({ color: "red" })
+    );
+  },
+  get mat_basic_black_wireframe(): MeshBasicMaterial {
+    return getResource<MeshBasicMaterial>(
+      "mat_basic_black_wireframe",
+      () => new MeshBasicMaterial({ color: "black", wireframe: true })
+    );
+  },
+  get geo_rounded_box_1x1(): RoundedBoxGeometry {
+    return getResource<RoundedBoxGeometry>(
+      "geo_rounded_box_1x1",
+      () => new RoundedBoxGeometry(1, 1, 0.25, 4, 0.125)
+    );
+  },
+  get geo_rounded_box_1x0_35(): RoundedBoxGeometry {
+    return getResource<RoundedBoxGeometry>(
+      "geo_rounded_box_1x0_35",
+      () => new RoundedBoxGeometry(1, 0.35, 0.125, 4, 0.0625)
+    );
+  },
+  get geo_rounded_box_1x0_3(): RoundedBoxGeometry {
+    return getResource<RoundedBoxGeometry>(
+      "geo_rounded_box_1x0_3",
+      () => new RoundedBoxGeometry(1, 0.3, 0.1, 4, 0.05)
+    );
+  },
+};

--- a/src/tools/WalkieTalkie/components/Option.tsx
+++ b/src/tools/WalkieTalkie/components/Option.tsx
@@ -1,5 +1,6 @@
 import { GroupProps } from "@react-three/fiber";
-import { RoundedBox, Text } from "@react-three/drei";
+import { Text } from "@react-three/drei";
+import { RoundedBox } from "../../../ideas/primitives/RoundedBox";
 import { Interactable } from "../../../ideas/modifiers/Interactable";
 import { useSpring, animated } from "@react-spring/three";
 import { useState } from "react";
@@ -32,10 +33,7 @@ export function Option(props: OptionProps) {
         onHover={() => setHovered(true)}
         onUnHover={() => setHovered(false)}
       >
-        <RoundedBox
-          args={[width, FONT_SIZE + PADDING_Y * 2, DEPTH]}
-          radius={Math.min(width, FONT_SIZE, DEPTH) * 0.5}
-        >
+        <RoundedBox args={[width, FONT_SIZE + PADDING_Y * 2, DEPTH]}>
           {/* @ts-ignore */}
           <animated.meshStandardMaterial color={color} />
         </RoundedBox>

--- a/src/tools/WalkieTalkie/components/Option.tsx
+++ b/src/tools/WalkieTalkie/components/Option.tsx
@@ -1,9 +1,9 @@
 import { GroupProps } from "@react-three/fiber";
 import { Text } from "@react-three/drei";
 import { RoundedBox } from "../../../ideas/primitives/RoundedBox";
-import { Interactable } from "../../../ideas/modifiers/Interactable";
 import { useSpring, animated } from "@react-spring/three";
 import { useState } from "react";
+import { HitBox } from "../../../ideas/primitives/HitBox";
 
 type OptionProps = {
   onClick: () => void;
@@ -28,16 +28,16 @@ export function Option(props: OptionProps) {
 
   return (
     <group name="option" {...rest}>
-      <Interactable
+      <RoundedBox args={[width, FONT_SIZE + PADDING_Y * 2, DEPTH]}>
+        {/* @ts-ignore */}
+        <animated.meshStandardMaterial color={color} />
+      </RoundedBox>
+      <HitBox
+        args={[width, FONT_SIZE + PADDING_Y * 2, DEPTH]}
         onClick={onClick}
         onHover={() => setHovered(true)}
         onUnHover={() => setHovered(false)}
-      >
-        <RoundedBox args={[width, FONT_SIZE + PADDING_Y * 2, DEPTH]}>
-          {/* @ts-ignore */}
-          <animated.meshStandardMaterial color={color} />
-        </RoundedBox>
-      </Interactable>
+      />
       <group position-z={DEPTH / 2 + 0.001}>
         <Text
           fontSize={FONT_SIZE}

--- a/src/tools/WalkieTalkie/components/Pane.tsx
+++ b/src/tools/WalkieTalkie/components/Pane.tsx
@@ -1,5 +1,6 @@
 import { GroupProps } from "@react-three/fiber";
 import { ReactNode } from "react";
+import { universe } from "../../../logic";
 
 type PaneProps = {
   width: number;
@@ -14,9 +15,8 @@ export default function Pane(props: PaneProps) {
 
   return (
     <group name="pane" {...rest}>
-      <mesh>
+      <mesh material={universe.mat_standard_black}>
         <planeBufferGeometry args={[width + BORDER * 2, height + BORDER * 2]} />
-        <meshStandardMaterial color="black" />
       </mesh>
       <mesh position-z={0.001}>
         <planeBufferGeometry args={[width, height]} />

--- a/src/tools/WalkieTalkie/components/Pane.tsx
+++ b/src/tools/WalkieTalkie/components/Pane.tsx
@@ -1,6 +1,6 @@
 import { GroupProps } from "@react-three/fiber";
 import { ReactNode } from "react";
-import { universe } from "../../../logic";
+import { cache } from "../../../logic/cache";
 
 type PaneProps = {
   width: number;
@@ -15,7 +15,7 @@ export default function Pane(props: PaneProps) {
 
   return (
     <group name="pane" {...rest}>
-      <mesh material={universe.mat_standard_black}>
+      <mesh material={cache.mat_standard_black}>
         <planeBufferGeometry args={[width + BORDER * 2, height + BORDER * 2]} />
       </mesh>
       <mesh position-z={0.001}>

--- a/src/tools/WalkieTalkie/components/Request.tsx
+++ b/src/tools/WalkieTalkie/components/Request.tsx
@@ -1,5 +1,7 @@
 import { GroupProps } from "@react-three/fiber";
-import { RoundedBox, Text } from "@react-three/drei";
+import { Text } from "@react-three/drei";
+import { RoundedBox } from "../../../ideas/primitives/RoundedBox";
+import { universe } from "../../../logic";
 
 type RequestProps = { width: number } & GroupProps;
 
@@ -29,10 +31,8 @@ export default function Request(props: RequestProps) {
       </Text>
       <RoundedBox
         args={[width, FONT_SIZE * 2 + PADDING_Y * 4, DEPTH]}
-        radius={Math.min(width, FONT_SIZE, DEPTH) * 0.5}
-      >
-        <meshStandardMaterial color="white" />
-      </RoundedBox>
+        material={universe.mat_standard_white}
+      />
     </group>
   );
 }

--- a/src/tools/WalkieTalkie/components/Request.tsx
+++ b/src/tools/WalkieTalkie/components/Request.tsx
@@ -1,7 +1,7 @@
 import { GroupProps } from "@react-three/fiber";
 import { Text } from "@react-three/drei";
 import { RoundedBox } from "../../../ideas/primitives/RoundedBox";
-import { universe } from "../../../logic";
+import { cache } from "../../../logic/cache";
 
 type RequestProps = { width: number } & GroupProps;
 
@@ -31,7 +31,7 @@ export default function Request(props: RequestProps) {
       </Text>
       <RoundedBox
         args={[width, FONT_SIZE * 2 + PADDING_Y * 4, DEPTH]}
-        material={universe.mat_standard_white}
+        material={cache.mat_standard_white}
       />
     </group>
   );

--- a/src/tools/WalkieTalkie/components/TalkieModel.tsx
+++ b/src/tools/WalkieTalkie/components/TalkieModel.tsx
@@ -1,4 +1,4 @@
-import { RoundedBox } from "@react-three/drei";
+import { RoundedBox } from "../../../ideas/primitives/RoundedBox";
 import { useModifiedStandardShader } from "../../../logic/material";
 import { frag, vert } from "../materials/walkie";
 
@@ -18,19 +18,12 @@ export default function TalkieModel(props: TalkieModelProps) {
 
   return (
     <group name="model">
-      <RoundedBox
-        args={[width, height, depth]}
-        radius={Math.min(width, height, depth) * 0.5}
-        material={mat}
-        smoothness={10}
-      />
+      <RoundedBox args={[width, height, depth]} material={mat} />
       <RoundedBox
         args={[ANTENNA_WIDTH, ANTENNA_HEIGHT, depth]}
         material={mat}
-        radius={Math.min(ANTENNA_WIDTH, height, depth) * 0.5}
         position-x={-width / 2 + ANTENNA_WIDTH / 2}
         position-y={height / 2}
-        smoothness={10}
       />
     </group>
   );


### PR DESCRIPTION
- new `RoundedBox` component that has some cached geometries and, compared to Drei's, generates faster and has smooth UVs
- new `Hitbox` component to create a box geometry used for approximating raycasts, greatly improves speed
- new `cache` logic to pull geometries and materials as well as an api to cache custom resources
- resize `Dialogue`'s `Bubble`s to fix raycasting issues
- add `Hitbox` in a few spots where needed